### PR TITLE
Add boolean util tests

### DIFF
--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/util/BooleanUtilTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/util/BooleanUtilTest.java
@@ -1,3 +1,22 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
 package org.opengrok.indexer.util;
 
 import org.junit.Assert;

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/util/BooleanUtilTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/util/BooleanUtilTest.java
@@ -1,0 +1,93 @@
+package org.opengrok.indexer.util;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class BooleanUtilTest {
+
+  @Rule public final ExpectedException thrown = ExpectedException.none();
+
+  /* testedClasses: BooleanUtil */
+  // Test written by Diffblue Cover.
+
+  @Test
+  public void constructorOutputVoid() {
+
+    // Act, creating object to test constructor
+    final BooleanUtil objectUnderTest = new BooleanUtil();
+
+    // Method returns void, testing that no exception is thrown
+  }
+
+  // Test written by Diffblue Cover.
+  @Test
+  public void isBooleanInputNotNullOutputFalse() {
+
+    // Arrange
+    final String value = "3";
+
+    // Act
+    final boolean actual = BooleanUtil.isBoolean(value);
+
+    // Assert result
+    Assert.assertFalse(actual);
+  }
+
+  // Test written by Diffblue Cover.
+  @Test
+  public void isBooleanInputNotNullOutputTrue() {
+
+    // Arrange
+    final String value = "1";
+
+    // Act
+    final boolean actual = BooleanUtil.isBoolean(value);
+
+    // Assert result
+    Assert.assertTrue(actual);
+  }
+
+  // Test written by Diffblue Cover.
+  @Test
+  public void isBooleanInputNotNullOutputTrue2() {
+
+    // Arrange
+    final String value = "faLSe";
+
+    // Act
+    final boolean actual = BooleanUtil.isBoolean(value);
+
+    // Assert result
+    Assert.assertTrue(actual);
+  }
+
+  // Test written by Diffblue Cover.
+  @Test
+  public void toIntegerInputFalseOutputZero() {
+
+    // Arrange
+    final boolean b = false;
+
+    // Act
+    final int actual = BooleanUtil.toInteger(b);
+
+    // Assert result
+    Assert.assertEquals(0, actual);
+  }
+
+  // Test written by Diffblue Cover.
+  @Test
+  public void toIntegerInputTrueOutputPositive() {
+
+    // Arrange
+    final boolean b = true;
+
+    // Act
+    final int actual = BooleanUtil.toInteger(b);
+
+    // Assert result
+    Assert.assertEquals(1, actual);
+  }
+}


### PR DESCRIPTION
Hi,

I've analysed your code base and noticed that `org.opengrok.indexer.util.BooleanUtil` in the `opengrok` module is not fully tested.

These tests have been created by [Diffblue Cover](https://www.diffblue.com/opensource).

Hopefully, these tests should help you detect any regressions caused by future code changes. If you would find it useful to have additional tests written for this repository, I would be more than happy to look at other particular classes that you consider important.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
